### PR TITLE
Allow nbofdaysprior to be -1 and allow registration in the past

### DIFF
--- a/public_html/app/teststarregistrationview/periods.form.html
+++ b/public_html/app/teststarregistrationview/periods.form.html
@@ -15,32 +15,32 @@
 				<div ng-repeat="period in currentTestregistration.periods | filter:filterPeriods" class="blackcurvyborder">
 					<div class="row">
 						<div class="col-xs-2">
-							<label for="perioddate">{{translationObj.period.fieldperioddate}}</label>
-							<input type="text" class="form-control" id="perioddate" ng-model="period.perioddate" disabled>
+							<label for="perioddate{{$index}}">{{translationObj.period.fieldperioddate}}</label>
+							<input type="text" class="form-control" id="perioddate{{$index}}" ng-model="period.perioddate" disabled>
 						</div>
 						<div class="col-xs-2">
-							<label for="day">{{translationObj.period.fieldday}}</label>
-							<select class="form-control" id="day" ng-model="period.day" disabled>
+							<label for="day{{$index}}">{{translationObj.period.fieldday}}</label>
+							<select class="form-control" id="day{{$index}}" ng-model="period.day" disabled>
 								<option ng-repeat="day1 in days" value="{{day1.code}}">{{day1.text}}</option>
 							</select>
 						</div>
 						<div class="col-xs-2">
-				      <label for="arena">{{translationObj.period.fieldarena}}</label>
-		      		<select class="form-control" id="arena" ng-model="period.arenaid" disabled>
+				      <label for="arena{{$index}}">{{translationObj.period.fieldarena}}</label>
+		      		<select class="form-control" id="arena{{$index}}" ng-model="period.arenaid" disabled>
 								<option ng-repeat="arena in arenas" value="{{arena.id}}">{{arena.label}}</option>
 		      		</select>
 			      </div>
 						<div class="col-xs-2">
-							<label for="ice">{{translationObj.period.fieldice}}</label>
-							<input type="text" class="form-control" id="ice" ng-model="period.icelabel" disabled>
+							<label for="ice{{$index}}">{{translationObj.period.fieldice}}</label>
+							<input type="text" class="form-control" id="ice{{$index}}" ng-model="period.icelabel" disabled>
 						</div>
 						<div class="col-xs-2">
-							<label for="starttime">{{translationObj.period.fieldstarttime}}</label>
-							<input type="text" class="form-control" id="starttime" ng-model="period.starttime" disabled>
+							<label for="starttime{{$index}}">{{translationObj.period.fieldstarttime}}</label>
+							<input type="text" class="form-control" id="starttime{{$index}}" ng-model="period.starttime" disabled>
 						</div>
 						<div class="col-xs-2">
-							<label for="endtime">{{translationObj.period.fieldendtime}}</label>
-							<input type="text" class="form-control" id="endtime" ng-model="period.endtime" disabled>
+							<label for="endtime{{$index}}">{{translationObj.period.fieldendtime}}</label>
+							<input type="text" class="form-control" id="endtime{{$index}}" ng-model="period.endtime" disabled>
 						</div>
 					</div>
 					<div class="row">

--- a/public_html/app/teststarregistrationview/teststarregistrationview.js
+++ b/public_html/app/teststarregistrationview/teststarregistrationview.js
@@ -245,6 +245,11 @@ angular.module('cpa_admin.teststarregistrationview', ['ngRoute'])
     var today = new Date();
     today.setHours(0,0,0,0);
 
+    // -1 is a special case when we allow registrations to be done in the past
+    if (obj.nbofdaysprior == -1) {
+      obj.canedit = true;
+      return true;
+    }
     // if (realDate >= today) {
     if (today <= realDate) {
       obj.canedit = true;

--- a/public_html/app/teststarregistrationview/teststarregistrationview.php
+++ b/public_html/app/teststarregistrationview/teststarregistrationview.php
@@ -32,7 +32,7 @@ function getAllPeriods($mysqli, $language) {
 											(select getTextLabel(cai.label, '$language') from cpa_arenas_ices cai where cai.arenaid = cnsp.arenaid and cai.id = cnsp.iceid) icelabel
 							FROM cpa_newtests_sessions_periods cnsp
 							JOIN cpa_newtests_sessions cns ON cns.id = cnsp.newtestssessionsid
-							WHERE perioddate >= curdate()
+							WHERE (perioddate >= curdate() or cns.nbofdaysprior = -1)
 							AND cnsp.canceled = 0
 							ORDER BY perioddate, arenaid, iceid";
 		$result = $mysqli->query($query);

--- a/public_html/app/teststarsessionview/teststarsessionview.js
+++ b/public_html/app/teststarsessionview/teststarsessionview.js
@@ -151,7 +151,7 @@ angular.module('cpa_admin.teststarsessionview', ['ngRoute'])
 		$scope.globalErrorMessage = [];
 		$scope.globalWarningMessage = [];
 
-		if ($scope.currentTestsession.nbofdaysprior < 0 || $scope.currentTestsession.nbofdaysprior > 30) {
+		if ($scope.currentTestsession.nbofdaysprior < -1 || $scope.currentTestsession.nbofdaysprior > 30) {
 				$scope.globalErrorMessage.push($scope.translationObj.main.msgerrnbofdayspriorinvalid);
 		}
 


### PR DESCRIPTION
Allow nbofdaysprior to be -1 for a test session to make all test periods of that session opened to registration, even if period is in the past. This is to allow coaches to retroactively register the skaters' tests in the system. Test director still has to approve and grade every test, but the coaches can now help with the retro registration.